### PR TITLE
PBR-411 : NPE if web.xml doesn't declare FacesServlet

### DIFF
--- a/core/portletbridge-impl/src/main/java/org/jboss/portletbridge/PortletBridgeImpl.java
+++ b/core/portletbridge-impl/src/main/java/org/jboss/portletbridge/PortletBridgeImpl.java
@@ -155,6 +155,13 @@ public class PortletBridgeImpl implements Bridge {
 
         // Process web.xml content
         WebXmlProcessor webXmlProc = new WebXmlProcessor(portletConfig.getPortletContext());
+        // Check if we have what we need to proceed
+        if (webXmlProc.getFacesServlet() == null) {
+            throw new BridgeException("No Faces Servlet defined in web.xml");
+        }
+        if (webXmlProc.getFacesServlet().getMappings() == null) {
+            throw new BridgeException("No Servlet Mapping defined in web.xml");
+        }
         // Retrieve Faces Servlet Mapping
         bridgeConfig.setFacesServletMappings(webXmlProc.getFacesServlet().getMappings());
         // Retrieve Error Page Mapping


### PR DESCRIPTION
Initial fix is to throw a BridgeException when configuring Bridge, if no Servlet and/or mapping is not found
