### PR TITLE
PBR-438: use the getContentLength method instead of searching for a cont...

### DIFF
--- a/extension/richfaces/src/main/java/org/jboss/portletbridge/richfaces/context/FileUploadFacesContextFactory.java
+++ b/extension/richfaces/src/main/java/org/jboss/portletbridge/richfaces/context/FileUploadFacesContextFactory.java
@@ -72,7 +72,7 @@ public class FileUploadFacesContextFactory extends FacesContextFactory implement
                 String uid = clientRequest.getParameter(org.richfaces.context.FileUploadFacesContextFactory.UID_KEY);
 
                 if (null != uid) {
-                    long contentLength = Long.parseLong(clientRequest.getProperty("content-length"));
+                    long contentLength = clientRequest.getContentLength();
 
                     ProgressControl progressControl = new ProgressControl(uid, contentLength);
 


### PR DESCRIPTION
...ent-length property. Fixes an NPE when the clientRequest doesn't not contian a content-length property
