### PR TITLE
PBR-570 BZ1162145 - Added special handling for exceptions in RenderResponse phase

### DIFF
--- a/core/impl/src/main/java/org/jboss/portletbridge/context/exception/PortletExceptionHandler.java
+++ b/core/impl/src/main/java/org/jboss/portletbridge/context/exception/PortletExceptionHandler.java
@@ -79,10 +79,13 @@ public class PortletExceptionHandler extends ExceptionHandlerWrapper {
                                 // this would happen if there's an error on the
                                 // errorView and would cause an infinite loop
                                 if (!errorView.equals(bridgeContext.getRedirectViewId())) {
-                                    fc.getExternalContext().responseReset();
-                                    fc.getExternalContext().setResponseBufferSize(-1);
+                                    // browser has seen already some content, so, we can't
+                                    // reset the buffer/response
+                                    if (!fc.getExternalContext().isResponseCommitted()) {
+                                        fc.getExternalContext().responseReset();
+                                        fc.getExternalContext().setResponseBufferSize(-1);
+                                    }
                                     bridgeContext.setRedirectViewId(errorView);
-
                                     bridgeContext.setRenderRedirect(true);
                                 }
                             } else {


### PR DESCRIPTION
When an exception occurs and the response was already partially sent, reset the buffer and set the bridgeContext to look for a redirected view, which is an errorView at this point.
